### PR TITLE
Implicit object literals in parenthesized args.

### DIFF
--- a/lib/coffee-script/parser.js
+++ b/lib/coffee-script/parser.js
@@ -4866,7 +4866,7 @@ module.exports = module.exports = (function(){
           return cachedResult.result;
         }
         
-        var r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12;
+        var r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15, r16;
         
         r1 = clone(pos);
         r2 = clone(pos);
@@ -4881,14 +4881,45 @@ module.exports = module.exports = (function(){
             if (r8 !== null) {
               r9 = parse__();
               if (r9 !== null) {
+                r11 = clone(pos);
                 if (input.charCodeAt(pos.offset) === 44) {
-                  r10 = ",";
+                  r12 = ",";
                   advance(pos, 1);
                 } else {
-                  r10 = null;
+                  r12 = null;
                   if (reportFailures === 0) {
                     matchFailed("\",\"");
                   }
+                }
+                if (r12 !== null) {
+                  r13 = parse__();
+                  if (r13 !== null) {
+                    r14 = parse_TERMINATOR();
+                    r14 = r14 !== null ? r14 : "";
+                    if (r14 !== null) {
+                      r15 = [];
+                      r16 = parse_INDENT();
+                      while (r16 !== null) {
+                        r15.push(r16);
+                        r16 = parse_INDENT();
+                      }
+                      if (r15 !== null) {
+                        r10 = [r12, r13, r14, r15];
+                      } else {
+                        r10 = null;
+                        pos = clone(r11);
+                      }
+                    } else {
+                      r10 = null;
+                      pos = clone(r11);
+                    }
+                  } else {
+                    r10 = null;
+                    pos = clone(r11);
+                  }
+                } else {
+                  r10 = null;
+                  pos = clone(r11);
                 }
                 if (r10 === null) {
                   r10 = parse_TERMINATOR();
@@ -4898,7 +4929,18 @@ module.exports = module.exports = (function(){
                   if (r11 !== null) {
                     r12 = parse_argument();
                     if (r12 !== null) {
-                      r5 = [r7, r8, r9, r10, r11, r12];
+                      r13 = [];
+                      r14 = parse_DEDENT();
+                      while (r14 !== null) {
+                        r13.push(r14);
+                        r14 = parse_DEDENT();
+                      }
+                      if (r13 !== null) {
+                        r5 = [r7, r8, r9, r10, r11, r12, r13];
+                      } else {
+                        r5 = null;
+                        pos = clone(r6);
+                      }
                     } else {
                       r5 = null;
                       pos = clone(r6);
@@ -4933,14 +4975,45 @@ module.exports = module.exports = (function(){
               if (r8 !== null) {
                 r9 = parse__();
                 if (r9 !== null) {
+                  r11 = clone(pos);
                   if (input.charCodeAt(pos.offset) === 44) {
-                    r10 = ",";
+                    r12 = ",";
                     advance(pos, 1);
                   } else {
-                    r10 = null;
+                    r12 = null;
                     if (reportFailures === 0) {
                       matchFailed("\",\"");
                     }
+                  }
+                  if (r12 !== null) {
+                    r13 = parse__();
+                    if (r13 !== null) {
+                      r14 = parse_TERMINATOR();
+                      r14 = r14 !== null ? r14 : "";
+                      if (r14 !== null) {
+                        r15 = [];
+                        r16 = parse_INDENT();
+                        while (r16 !== null) {
+                          r15.push(r16);
+                          r16 = parse_INDENT();
+                        }
+                        if (r15 !== null) {
+                          r10 = [r12, r13, r14, r15];
+                        } else {
+                          r10 = null;
+                          pos = clone(r11);
+                        }
+                      } else {
+                        r10 = null;
+                        pos = clone(r11);
+                      }
+                    } else {
+                      r10 = null;
+                      pos = clone(r11);
+                    }
+                  } else {
+                    r10 = null;
+                    pos = clone(r11);
                   }
                   if (r10 === null) {
                     r10 = parse_TERMINATOR();
@@ -4950,7 +5023,18 @@ module.exports = module.exports = (function(){
                     if (r11 !== null) {
                       r12 = parse_argument();
                       if (r12 !== null) {
-                        r5 = [r7, r8, r9, r10, r11, r12];
+                        r13 = [];
+                        r14 = parse_DEDENT();
+                        while (r14 !== null) {
+                          r13.push(r14);
+                          r14 = parse_DEDENT();
+                        }
+                        if (r13 !== null) {
+                          r5 = [r7, r8, r9, r10, r11, r12, r13];
+                        } else {
+                          r5 = null;
+                          pos = clone(r6);
+                        }
                       } else {
                         r5 = null;
                         pos = clone(r6);
@@ -4977,14 +5061,45 @@ module.exports = module.exports = (function(){
             }
           }
           if (r4 !== null) {
+            r6 = clone(pos);
             if (input.charCodeAt(pos.offset) === 44) {
-              r5 = ",";
+              r7 = ",";
               advance(pos, 1);
             } else {
-              r5 = null;
+              r7 = null;
               if (reportFailures === 0) {
                 matchFailed("\",\"");
               }
+            }
+            if (r7 !== null) {
+              r8 = parse__();
+              if (r8 !== null) {
+                r9 = [];
+                r10 = parse_DEDENT();
+                while (r10 !== null) {
+                  r9.push(r10);
+                  r10 = parse_DEDENT();
+                }
+                if (r9 !== null) {
+                  r10 = parse_TERMINATOR();
+                  r10 = r10 !== null ? r10 : "";
+                  if (r10 !== null) {
+                    r5 = [r7, r8, r9, r10];
+                  } else {
+                    r5 = null;
+                    pos = clone(r6);
+                  }
+                } else {
+                  r5 = null;
+                  pos = clone(r6);
+                }
+              } else {
+                r5 = null;
+                pos = clone(r6);
+              }
+            } else {
+              r5 = null;
+              pos = clone(r6);
             }
             if (r5 === null) {
               r5 = parse_TERMINATOR();
@@ -5067,11 +5182,40 @@ module.exports = module.exports = (function(){
           return cachedResult.result;
         }
         
-        var r0;
+        var r0, r1, r2, r3, r4, r5;
         
-        r0 = parse_spread();
+        r1 = clone(pos);
+        r2 = clone(pos);
+        r3 = parse_TERMINDENT();
+        if (r3 !== null) {
+          r4 = parse_implicitObjectLiteral();
+          if (r4 !== null) {
+            r5 = parse_DEDENT();
+            if (r5 !== null) {
+              r0 = [r3, r4, r5];
+            } else {
+              r0 = null;
+              pos = clone(r2);
+            }
+          } else {
+            r0 = null;
+            pos = clone(r2);
+          }
+        } else {
+          r0 = null;
+          pos = clone(r2);
+        }
+        if (r0 !== null) {
+          r0 = (function(offset, line, column, t, o, d) { return o; })(r1.offset, r1.line, r1.column, r3, r4, r5);
+        }
         if (r0 === null) {
-          r0 = parse_expression();
+          pos = clone(r1);
+        }
+        if (r0 === null) {
+          r0 = parse_spread();
+          if (r0 === null) {
+            r0 = parse_expression();
+          }
         }
         
         cache[cacheKey] = {

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -398,7 +398,7 @@ leftHandSideExpression = callExpression / newExpression
           };
       }
   argumentListContents
-    = e:argument es:(_ TERM? _ ("," / TERMINATOR) _ argument)* t:("," / TERMINATOR)? {
+    = e:argument es:(_ TERM? _ ("," _ TERMINATOR? INDENT* / TERMINATOR) _ argument DEDENT*)* t:("," _ DEDENT* TERMINATOR? / TERMINATOR)? {
         var raw = e.raw + es.map(function(e){ return e[0] + e[1] + e[2] + e[3] + e[4] + e[5].raw; }).join('') + t;
         return {list: [e].concat(es.map(function(e){ return e[5]; })), raw: raw};
       }
@@ -406,7 +406,8 @@ leftHandSideExpression = callExpression / newExpression
         return {list: a.list, raw: t0 + a.raw + d + t1};
       }
   argument
-    = spread
+    = t:TERMINDENT o:implicitObjectLiteral d:DEDENT { return o; }
+    / spread
     / expression
   secondaryArgumentList
     = ws0:__ !([+-/] __) e:secondaryArgument es:(secondaryArgumentRest)* {

--- a/test/objects.coffee
+++ b/test/objects.coffee
@@ -153,6 +153,74 @@ suite 'Object Literals', ->
 
       throws -> CoffeeScript.compile 'a = b:1, c'
 
+    test 'invoking functions with implicit object literals (with parens)', ->
+      generateGetter = (prop) -> (obj) -> obj[prop]
+      getA = generateGetter 'a'
+      getArgs = -> arguments
+      a = b = 30
+
+      result = getA(
+        a: 10
+      )
+      eq 10, result
+
+      result = getA(
+        'a': 20
+      )
+      eq 20, result
+
+      result = getA(a,
+        b:1
+      )
+      eq undefined, result
+
+      result = getA(b:1,
+      a:43
+      )
+      eq 43, result
+
+      result = getA(b:1,
+        a:62
+      )
+      eq undefined, result
+    # result = getA(
+    #   b:1
+    #   a
+    # )
+    # eq undefined, result
+
+      result = getA(
+        a:
+          b:2
+        b:1
+      )
+      eq 2, result.b
+
+    # result = getArgs(
+    #   a:1
+    #   b
+    #   c:1
+    # )
+    # ok result.length is 3
+    # ok result[2].c is 1
+
+      result = getA(b: 13, a: 42, 2)
+      eq 42, result
+
+      result = getArgs(a:1, (1 + 1))
+      ok result[1] is 2
+
+      result = getArgs(a:1, b)
+      ok result.length is 2
+      ok result[1] is 30
+
+      result = getArgs(a:1, b, b:1, a)
+      ok result.length is 4
+      ok result[2].b is 1
+
+      throws -> CoffeeScript.compile 'a = b:1, c'
+
+
     #test 'multiple dedentations in implicit object literals', ->
     #  nonce0 = {}
     #  nonce1 = {}


### PR DESCRIPTION
Supports the following forms (as generated by e.g. js2coffee):

```
console.log(1,
  name: name
  , 2)

console.log(
  name: name
  , 4)

console.log(name: name
, 8)
```

  And also this form with arbitrary indent/dedent around commas:

```
console.log(1,
  2,
  4,
)
```
